### PR TITLE
build: Adicionar /dist para gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
# Update do Gitignore
Tudo dentro da /dist é uma versão comprimida do código fonte para rodar na web. Não é relevante para o desenvolvimento conter um arquivo desse uma vez que ferramentas de deploy que interpretam no mínimo javascript já possuem a capacidade de realizar essa tarefa.

Vale acrescentar que essa pasta só é criada pelo comando ```npm run build``` para testar a capacidade de build local