### PR TITLE
Modal Tipos de locais

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "navgo-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
@@ -662,6 +663,18 @@
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.1.tgz",
+      "integrity": "sha512-3p30hdo4LlRZTT5CwoAJq3G9fHI0wDc0pBaMHj4SUn0yomO+RcDRlzhdXqdr5cVnzax44sqXJVnf3oQG0eI+4g==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",

--- a/src/components/ModalBody/LocalTypeBody/CreateLocalType/index.jsx
+++ b/src/components/ModalBody/LocalTypeBody/CreateLocalType/index.jsx
@@ -1,6 +1,6 @@
 import api from "../../../../api";
 import { useState } from "react";
-import { Text, Box, Input, Button, FormControl, FormLabel, useToast } from "@chakra-ui/react";
+import { Text, Box, Input, Button, FormControl, FormLabel, useToast, Tooltip } from "@chakra-ui/react";
 import { InfoOutlineIcon } from "@chakra-ui/icons";
 
 const LocalTypeBody = () => {
@@ -41,19 +41,19 @@ const LocalTypeBody = () => {
                 <Input
                     value={typeName}
                     onChange={(e) => setTypeName(e.target.value)}
-                    placeholder="Sala de aula"
+                    placeholder="Nome do tipo de local"
                     mb={4}
                 />
                 <FormLabel display="flex" alignItems="center">
                     Descrição do local 
-                    <Tooltip label="Descreva a função e as características deste local." fontSize="sm">
+                    <Tooltip label="Descreva a função e as características deste tipo de local, como por exemplo as atividades mais realizadas neste local por alunos ou docentes">
                         <InfoOutlineIcon ml={2} />
                     </Tooltip>
                 </FormLabel>
                 <Input
                     value={description}
                     onChange={(e) => setDescription(e.target.value)}
-                    placeholder="Sala utilizada para aulas teóricas, com projetor e televisão para..."
+                    placeholder="Descrição do tipo de local"
                     mb={8}
                 />
                 <Box textAlign={'center'}>

--- a/src/components/ModalBody/LocalTypeBody/CreateLocalType/index.jsx
+++ b/src/components/ModalBody/LocalTypeBody/CreateLocalType/index.jsx
@@ -1,0 +1,78 @@
+import api from "../../../../api";
+import { useState } from "react";
+import { Text, Box, Input, Button, FormControl, FormLabel, useToast } from "@chakra-ui/react";
+import { InfoOutlineIcon } from "@chakra-ui/icons";
+
+const LocalTypeBody = () => {
+    const toast = useToast();
+    const [typeName, setTypeName] = useState("");
+    const [description, setDescription] = useState("");
+
+    const handleSubmit = async () => {
+        try {
+            await api.post("/local-type", { type_name: typeName, description: description });
+            toast({
+                title: "Tipo de local cadastrado com sucesso!",
+                status: "success",
+                duration: 3000,
+                isClosable: true,
+                position: "top",
+            });
+        } catch (error) {
+            const errorMessage = error.response?.data?.message || "Erro ao cadastrar tipo de local.";
+            toast({
+                title: "Erro ao cadastrar tipo de local.",
+                description: errorMessage,
+                status: "error",
+                duration: 3000,
+                isClosable: true,
+                position: "top",
+            });
+        }
+    };
+
+    return (
+        <Box>
+            <Text as="header" w={"100%"} textAlign={"center"} mb={4}>
+                Cadastre novos tipos de locais:
+            </Text>
+            <FormControl>
+                <FormLabel>Nome do Tipo de Local</FormLabel>
+                <Input
+                    value={typeName}
+                    onChange={(e) => setTypeName(e.target.value)}
+                    placeholder="Sala de aula"
+                    mb={4}
+                />
+                <FormLabel display="flex" alignItems="center">
+                    Descrição do local 
+                    <Tooltip label="Descreva a função e as características deste local." fontSize="sm">
+                        <InfoOutlineIcon ml={2} />
+                    </Tooltip>
+                </FormLabel>
+                <Input
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Sala utilizada para aulas teóricas, com projetor e televisão para..."
+                    mb={8}
+                />
+                <Box textAlign={'center'}>
+                    <Button
+                        onClick={handleSubmit}
+                        color={'#fff'} 
+                        mb={3} 
+                        bg={'main.100'}
+                        _hover={{
+                            bg: 'main.200',
+                            cursor: 'pointer'
+                        }}
+                    >
+                        Cadastrar Tipo de Local
+                    </Button>
+                </Box>
+            </FormControl>
+        </Box>
+    );
+};
+
+export default LocalTypeBody;


### PR DESCRIPTION
Essa PR é sobre a modal do painel adminsitrativo "Tipos de locais"

A única coisa nova adicionada foi o pacote do chakra UI icons, para utiliza-lo na interface com o objetivo do usuário compreender melhor a finalidade do campo a ser preenchido.

![image](https://github.com/user-attachments/assets/aea2a936-1230-4ed9-87c3-54ac138dfb95)
![image](https://github.com/user-attachments/assets/85fb82a6-881b-45ff-90de-6c2990fadeaa)
